### PR TITLE
Parse given string to see if it is a date

### DIFF
--- a/src/event-tracker.coffee
+++ b/src/event-tracker.coffee
@@ -57,7 +57,18 @@ module.exports = (robot) ->
       else
         msg.send "#{(days_since*-1)} days until #{event}"
     else
-      msg.send "I don't recall when #{event} happened."
+      # Special case: if the event parses to a date
+      if moment(event).isValid()
+        dateEvent = moment(event)
+        days_since = moment().diff(dateEvent, 'days')
+        if days_since > 0
+          msg.send "It's been " + days_since + " days since #{dateEvent.format('l')}."
+        else if days_since == 0
+          msg.send "#{dateEvent.format('l')} is today!"
+        else
+          msg.send "#{(days_since*-1)} days until #{dateEvent.format('l')}"
+      else
+        msg.send "I don't recall when #{event} happened."
 
   robot.respond /when (was|is|did)?\s+(.*?)\??$/i, (msg) ->
     event = msg.match[2].trim()

--- a/test/event-tracker-test.coffee
+++ b/test/event-tracker-test.coffee
@@ -154,3 +154,16 @@ describe 'event-tracker', ->
       expect(@room.robot.brain.data.days_since).to.eql {
         'another thing': '2021-10-01'
       }
+
+  it 'responds to a generic date with days until', ->
+    Date.now = () ->
+      return Date.parse('Mon, 16 Aug 2021 12:00:00 UTC')
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot days until 5/17/2022').then =>
+      expect(selfRoom.messages).to.eql [
+        ['alice', '@hubot days until 5/17/2022']
+        ['hubot', '273 days until 5/17/2022']
+      ]
+      expect(@room.robot.brain.data.days_since).to.eql {
+        'another thing': '2021-10-01'
+      }


### PR DESCRIPTION
If an event doesn't match what's stored in the brain, check to see if it is a valid date string (return day until/since if it is) before bailing to the not found message.